### PR TITLE
[add] implement double tap action

### DIFF
--- a/lib/top.dart
+++ b/lib/top.dart
@@ -1,7 +1,9 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
 import 'package:retrospective_tool/input_form.dart';
+import 'package:retrospective_tool/widgets/browsing_kpt_note_widget.dart';
 import 'package:retrospective_tool/widgets/kpt_note_widget.dart';
 
 import 'model/kpt_note.dart';
@@ -14,7 +16,7 @@ class Top extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'Retrospective Tool',
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
@@ -62,7 +64,7 @@ class KptGridPage extends HookConsumerWidget {
       floatingActionButton: FloatingActionButton(
           child: const Icon(Icons.add),
           onPressed: () {
-            showCupertinoModalBottomSheet(
+            showBarModalBottomSheet(
               context: context,
               builder: (context) => const InputForm(),
             );
@@ -102,6 +104,15 @@ class KptGridPage extends HookConsumerWidget {
                 (BuildContext context, int index) {
                   return KptNoteWidget(
                     kptNote: list[index],
+                    onDoubleTap: () {
+                      showCupertinoModalPopup(
+                          context: context,
+                          builder: (BuildContext context) {
+                            return BrowsingKptNoteWidget(
+                              kptNote: list[index],
+                            );
+                          });
+                    },
                   );
                 },
                 childCount: list.length,

--- a/lib/widgets/browsing_kpt_note_widget.dart
+++ b/lib/widgets/browsing_kpt_note_widget.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:retrospective_tool/widgets/kpt_note_widget.dart';
+
+import '../model/kpt_note.dart';
+
+class BrowsingKptNoteWidget extends StatelessWidget {
+  const BrowsingKptNoteWidget({required this.kptNote, Key? key})
+      : super(key: key);
+  final KptNote kptNote;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      alignment: AlignmentDirectional.center,
+      children: [
+        GestureDetector(
+          onTap: () {
+            Navigator.pop(context);
+          },
+          child: FractionallySizedBox(
+            widthFactor: 1.0,
+            heightFactor: 1.0,
+            child: Opacity(
+              opacity: 0.5,
+              child: Container(color: Colors.black),
+            ),
+          ),
+        ),
+        FractionallySizedBox(
+            widthFactor: 1,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Expanded(
+                  flex: 8,
+                  child: AspectRatio(
+                    aspectRatio: 1,
+                    child: Row(
+                      children: [
+                        const Icon(
+                          Icons.arrow_left,
+                          size: 50,
+                          color: Colors.white,
+                        ),
+                        Expanded(
+                          child: AspectRatio(
+                            aspectRatio: 1,
+                            // TODO: 長文表示可能な専用のWidget作る
+                            child: KptNoteWidget(
+                              kptNote: kptNote,
+                            ),
+                          ),
+                        ),
+                        const Icon(
+                          Icons.arrow_right,
+                          size: 50,
+                          color: Colors.white,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                Expanded(
+                  flex: 1,
+                  child: Container(
+                    padding: const EdgeInsets.all(10.0),
+                    decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: Theme.of(context).primaryColor),
+                    child: Icon(
+                      Icons.delete,
+                      color: Theme.of(context).cardColor,
+                      size: 30,
+                    ),
+                  ),
+                )
+              ],
+            ))
+      ],
+    );
+  }
+}

--- a/lib/widgets/kpt_note_widget.dart
+++ b/lib/widgets/kpt_note_widget.dart
@@ -3,34 +3,39 @@ import 'package:flutter/material.dart';
 import '../model/kpt_note.dart';
 
 class KptNoteWidget extends StatelessWidget {
-  const KptNoteWidget({required this.kptNote, Key? key}) : super(key: key);
+  const KptNoteWidget({required this.kptNote, this.onDoubleTap, Key? key})
+      : super(key: key);
   final KptNote kptNote;
+  final Function()? onDoubleTap;
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      color: _getColor(kptNote.category),
-      child: Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              kptNote.title,
-              style: Theme.of(context).textTheme.headlineSmall,
-              textAlign: TextAlign.left,
-              overflow: TextOverflow.ellipsis,
-              maxLines: 1,
-            ),
-            Expanded(
-              child: Text(
-                kptNote.description,
+    return GestureDetector(
+      onDoubleTap: onDoubleTap,
+      child: Card(
+        color: _getColor(kptNote.category),
+        child: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                kptNote.title,
+                style: Theme.of(context).textTheme.headlineSmall,
                 textAlign: TextAlign.left,
                 overflow: TextOverflow.ellipsis,
-                maxLines: 4,
+                maxLines: 1,
               ),
-            ),
-          ],
+              Expanded(
+                child: Text(
+                  kptNote.description,
+                  textAlign: TextAlign.left,
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 4,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
- ダブルタップ時のモーダルを実装しました（モーダル画面は仮です。中身実装してません）
- 名前をFlutter DemoからRetrospective Toolに変えました
- InputForm表示時のmodalをBarTypeにしました（上にBarが付いてたほうが使いやすそうな気がしたので）

# Sample image
<img width="250" alt="image" src="https://user-images.githubusercontent.com/22520603/178323522-96bff4ef-4cbd-45ca-b7a8-c21f937dd5a2.png">

