### PR TITLE
[modify] Quick Browsing KPT画面を改善

### DIFF
--- a/lib/utils/kpt_note_util.dart
+++ b/lib/utils/kpt_note_util.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class KptNoteUtil {
+  static Color getColor(String category) {
+    switch (category) {
+      case "Keep":
+        return Colors.blue[100]!;
+      case "Problem":
+        return Colors.yellow[100]!;
+      case "Try":
+        return Colors.green[100]!;
+      default:
+        return Colors.red;
+    }
+  }
+}

--- a/lib/widgets/browsing_kpt_note_widget.dart
+++ b/lib/widgets/browsing_kpt_note_widget.dart
@@ -62,20 +62,17 @@ class BrowsingKptNoteWidget extends StatelessWidget {
                     ),
                   ),
                 ),
-                GestureDetector(
-                  onTap: onDelete,
-                  child: Container(
-                    padding: const EdgeInsets.all(10.0),
-                    decoration: BoxDecoration(
-                        shape: BoxShape.circle,
-                        color: Theme.of(context).primaryColor),
-                    child: Icon(
-                      Icons.delete,
-                      color: Theme.of(context).cardColor,
-                      size: 30,
-                    ),
+                RawMaterialButton(
+                  onPressed: onDelete,
+                  shape: const CircleBorder(),
+                  padding: const EdgeInsets.all(10.0),
+                  fillColor: Theme.of(context).primaryColor,
+                  child: Icon(
+                    Icons.delete,
+                    size: 30,
+                    color: Theme.of(context).cardColor,
                   ),
-                )
+                ),
               ],
             ))
       ],

--- a/lib/widgets/browsing_kpt_note_widget.dart
+++ b/lib/widgets/browsing_kpt_note_widget.dart
@@ -2,12 +2,20 @@ import 'package:flutter/material.dart';
 import 'package:retrospective_tool/widgets/kpt_note_widget.dart';
 
 import '../model/kpt_note.dart';
+import '../utils/kpt_note_util.dart';
 
 class BrowsingKptNoteWidget extends StatelessWidget {
-  const BrowsingKptNoteWidget({required this.kptNote, this.onDelete, Key? key})
+  const BrowsingKptNoteWidget(
+      {required this.kptNote,
+      this.onDelete,
+      this.onNext,
+      this.onPrevious,
+      Key? key})
       : super(key: key);
   final KptNote kptNote;
   final Function()? onDelete;
+  final Function()? onNext;
+  final Function()? onPrevious;
 
   @override
   Widget build(BuildContext context) {
@@ -47,9 +55,42 @@ class BrowsingKptNoteWidget extends StatelessWidget {
                         Expanded(
                           child: AspectRatio(
                             aspectRatio: 1,
-                            // TODO: 長文表示可能な専用のWidget作る
-                            child: KptNoteWidget(
-                              kptNote: kptNote,
+                            child: Card(
+                              color: KptNoteUtil.getColor(kptNote.category),
+                              child: Padding(
+                                padding: const EdgeInsets.all(8.0),
+                                child: Column(
+                                  children: [
+                                    SingleChildScrollView(
+                                      scrollDirection: Axis.horizontal,
+                                      child: Text(
+                                        kptNote.title,
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .headlineSmall,
+                                        textAlign: TextAlign.left,
+
+                                        // overflow: TextOverflow.ellipsis,
+                                      ),
+                                    ),
+                                    const SizedBox(
+                                      height: 4,
+                                    ),
+                                    Expanded(
+                                      child: CustomScrollView(
+                                        slivers: [
+                                          SliverToBoxAdapter(
+                                            child: Text(
+                                              kptNote.description,
+                                              textAlign: TextAlign.left,
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
                             ),
                           ),
                         ),

--- a/lib/widgets/kpt_note_widget.dart
+++ b/lib/widgets/kpt_note_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../model/kpt_note.dart';
+import '../utils/kpt_note_util.dart';
 
 class KptNoteWidget extends StatelessWidget {
   const KptNoteWidget({required this.kptNote, this.onDoubleTap, Key? key})
@@ -13,7 +14,7 @@ class KptNoteWidget extends StatelessWidget {
     return GestureDetector(
       onDoubleTap: onDoubleTap,
       child: Card(
-        color: _getColor(kptNote.category),
+        color: KptNoteUtil.getColor(kptNote.category),
         child: Padding(
           padding: const EdgeInsets.all(8.0),
           child: Column(
@@ -39,18 +40,5 @@ class KptNoteWidget extends StatelessWidget {
         ),
       ),
     );
-  }
-
-  _getColor(String category) {
-    switch (category) {
-      case "Keep":
-        return Colors.blue[100];
-      case "Problem":
-        return Colors.yellow[100];
-      case "Try":
-        return Colors.green[100];
-      default:
-        return Colors.red;
-    }
   }
 }


### PR DESCRIPTION
- ボタンのWidgetを変更
- onPrevious, onNextの画面切り替え用イベント委譲プロパティ追加（実装は書いてないです。。。力尽きた。。）
- 長文用のスクロール可能なカードに変更。タイトルは水平スクロールにしてますがここは好み分かれるかも。。
<img width="250" alt="image" src="https://user-images.githubusercontent.com/22520603/178786657-67b984f8-20e2-407e-90b2-802e884f4138.png">
